### PR TITLE
Remove duplicate location content block from 911 tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -3945,10 +3945,6 @@
                     <iframe id="text911Frame" style="border:none;width:100%;height:1px;" scrolling="no"></iframe>
                 </div>
             </div>
-        <div id="location-content" style="display:none;">
-            <iframe id="text911Frame" style="border:none;width:100%;height:600px;"></iframe>
-        </div>
-        </div>
         </div>
     </div>
     <script src="session.js"></script>


### PR DESCRIPTION
## Summary
- remove redundant location-content and iframe from text911Tab
- ensure content, container, and text911Tab close properly

## Testing
- `npm test` (fails: ENOENT, could not read package.json)


------
https://chatgpt.com/codex/tasks/task_b_68b103cb14208332886a36493d16fea9