### PR TITLE
Fix narrow iframe view by enforcing full-width tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,7 +51,10 @@
             padding-top: 80px !important;
         }
 
-        #healthRecordsTab {
+        #healthRecordsTab,
+        #clientCreatorTab,
+        #qrTab,
+        #text911Tab {
             width: 100%;
         }
 


### PR DESCRIPTION
## Summary
- Ensure client creator, QR, and text tabs span the full viewport width to prevent narrow embeds.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b10b885bd08332b9b307672461bbd6