### PR TITLE
Support v2 hash URLs in client QR creator

### DIFF
--- a/client-qr-creator.html
+++ b/client-qr-creator.html
@@ -49,7 +49,7 @@
     <header style="display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:18px">
       <div>
         <h1 style="margin:0;font-size:26px;letter-spacing:.2px">Client QR Creator</h1>
-        <div class="mini">Targets <span class="pill">https://clovenbradshaw-ctrl.github.io/ikey3/</span><span class="pill">&lt;guid&gt;#&lt;encryption&gt;</span></div>
+        <div class="mini">Targets <span class="pill">https://clovenbradshaw-ctrl.github.io/ikey3/</span><span class="pill">#v2:&lt;guid&gt;:&lt;encryption&gt;:&lt;embedded&gt;</span></div>
       </div>
       <div class="stack">
         <span id="statusBadge" class="badge ok">Ready</span>
@@ -158,7 +158,15 @@
     return btoa(s).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'');
   }
   function buildUrl(guid,key){
-    return `${VIEWER_URL}${guid}#${key}`;
+    const embedded = btoa(
+      JSON.stringify({
+        n: cName.value.trim(),
+        b: cBlood.value.trim(),
+        a: cAllergies.value.trim().substring(0,2000),
+        t: new Date().toISOString()
+      })
+    );
+    return `${VIEWER_URL}#v2:${guid}:${key}:${embedded}`;
   }
   function showToast(msg='Done'){
     const t=document.getElementById('toast');


### PR DESCRIPTION
## Summary
- Output URLs using `#v2:<guid>:<key>:<embedded>` so they resolve to `index.html`
- Update helper text to reflect the new QR URL format

## Testing
- `node -e "..."`
- `curl -I https://clovenbradshaw-ctrl.github.io/ikey3/` *(fails: 403 Forbidden)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b10fa6390c8332a5baad077ae26cfd