### PR TITLE
feat: make viewer URL configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# ikey3
+
+## Configuring the Viewer URL
+
+`client-qr-creator.html` builds QR codes that point to a viewer page. The base
+URL for this viewer is derived from the current location:
+
+```js
+const VIEWER_URL = window.IKEY3_VIEWER_URL || new URL('../', window.location.href).href;
+```
+
+To target a different viewer in another environment, define a global
+`IKEY3_VIEWER_URL` before the page's script runs:
+
+```html
+<script>window.IKEY3_VIEWER_URL = 'https://example.com/ikey3/';</script>
+```
+
+This overrides the default and ensures generated URLs and on‑page messaging use
+the specified base path.
+

--- a/client-qr-creator.html
+++ b/client-qr-creator.html
@@ -49,7 +49,7 @@
     <header style="display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:18px">
       <div>
         <h1 style="margin:0;font-size:26px;letter-spacing:.2px">Client QR Creator</h1>
-        <div class="mini">Targets <span class="pill">https://clovenbradshaw-ctrl.github.io/ikey3/</span><span class="pill">&lt;guid&gt;#&lt;encryption&gt;</span></div>
+        <div class="mini">Targets <span class="pill" id="viewerPrefix"></span><span class="pill">&lt;guid&gt;#&lt;encryption&gt;</span></div>
       </div>
       <div class="stack">
         <span id="statusBadge" class="badge ok">Ready</span>
@@ -140,7 +140,11 @@
   <div id="toast" class="toast" role="status" aria-live="polite">Copied!</div>
 
 <script>
-  const VIEWER_URL = 'https://clovenbradshaw-ctrl.github.io/ikey3/';
+  // Base URL for the viewer. Override by defining window.IKEY3_VIEWER_URL
+  // before this script runs. Defaults to the parent directory of the
+  // current location.
+  const VIEWER_URL = window.IKEY3_VIEWER_URL || new URL('../', window.location.href).href;
+  document.getElementById('viewerPrefix').textContent = VIEWER_URL;
 
   // ——— Helpers ———
   function generateGUID(){


### PR DESCRIPTION
## Summary
- derive viewer base URL from current location in `client-qr-creator.html`
- allow overriding the viewer URL via `window.IKEY3_VIEWER_URL` and update header dynamically
- document how to override the viewer URL in `README.md`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b10fa7617c83328beafc3deedffc10