### PR TITLE
Align PIN encryption with intake and fix viewer URLs

### DIFF
--- a/SYSTEM_DESIGN.md
+++ b/SYSTEM_DESIGN.md
@@ -71,10 +71,11 @@ sequenceDiagram
     participant A as App
     participant E as ThreeLayerEncryption
     U->>A: Enter emergency & medical data
-    A->>E: buildRecord(info, private, vault, password)
+    A->>E: buildRecord(info, private, vault, pin)
     E->>E: generateQrKey()
     E->>E: encrypt(publicData, qrKey)
-    E->>E: sha256(qrKey+password)
+    E->>E: derivePinKey(pin, pinSalt)
+    E->>E: encrypt(private, derivedPinKey)
     E->>E: deriveKey(qrKey, salt)
     E->>E: encrypt(vault, derivedKey)
     E-->>A: guid, qrKey, storedData

--- a/app.js
+++ b/app.js
@@ -112,7 +112,7 @@ class ThreeLayerEncryption {
   }
 
   // Build encrypted record and return GUID + qrKey
-  static async buildRecord(emergencyInfo, privateInfo, healthRecords, password, pin) {
+  static async buildRecord(emergencyInfo, privateInfo, healthRecords, pin) {
     const guid = self.crypto.randomUUID();
     const qrKey = this.generateQrKey();
 
@@ -146,13 +146,10 @@ class ThreeLayerEncryption {
     return await this.decrypt(storedData.publicData, qrKey);
   }
 
-  static async unlockPrivate(storedData, qrKey, password) {
-    const gate = await this.sha256(qrKey + password);
-    if (!storedData.privateInfo || storedData.privateInfo.encryptedWith !== gate) {
-      throw new Error('Invalid password');
-    }
-    const { encryptedWith, ...info } = storedData.privateInfo;
-    return info;
+  static async unlockPrivate(storedData, pin) {
+    const salt = new Uint8Array(this.base64ToArrayBuffer(storedData.pinSalt));
+    const pinKey = await this.derivePinKey(pin, salt);
+    return await this.decrypt(storedData.privateCipher, pinKey);
   }
 
   static async unlockVault(storedData, qrKey) {

--- a/client-qr-creator.html
+++ b/client-qr-creator.html
@@ -8,6 +8,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
+  <script src="app.js"></script>
   <style>
     :root{--bg:#0f172a;--card:#111827;--muted:#94a3b8;--text:#e5e7eb;--accent:#22d3ee;--outline:#1f2937;--ok:#10b981;--warn:#f59e0b;--err:#ef4444}
     *{box-sizing:border-box}
@@ -148,9 +149,8 @@
 
 <script>
   // Base URL for the viewer. Override by defining window.IKEY3_VIEWER_URL
-  // before this script runs. Defaults to the parent directory of the
-  // current location.
-  const VIEWER_URL = window.IKEY3_VIEWER_URL || new URL('../', window.location.href).href;
+  // before this script runs. Defaults to the current directory.
+  const VIEWER_URL = window.IKEY3_VIEWER_URL || new URL('./', window.location.href).href;
   document.getElementById('viewerPrefix').textContent = VIEWER_URL;
 
   // ——— Helpers ———
@@ -168,7 +168,7 @@
     for (const b of arr) s += String.fromCharCode(b);
     return btoa(s).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'');
   }
-  function buildUrl(guid,key,pin){
+  function buildUrl(guid,key){
     const embedded = btoa(
       JSON.stringify({
         n: cName.value.trim(),
@@ -248,7 +248,7 @@
   }
 
   function updateOutputs(){
-    const url = buildUrl(currentGUID,currentKey,pinEl.value.trim());
+    const url = buildUrl(currentGUID,currentKey);
     urlOut.textContent = url;
     renderQR(url);
   }
@@ -262,19 +262,31 @@
     updateOutputs(); showToast('New IDs generated');
   });
 
-  document.getElementById('saveClient').addEventListener('click', ()=>{
+  document.getElementById('saveClient').addEventListener('click', async ()=>{
     if(!validate()) return;
-    const clientInfo = {
+
+    const emergencyInfo = {
       name: cName.value.trim(),
-      publicInfo: {
-        bloodType: cBlood.value.trim(),
-        allergies: cAllergies.value.trim(),
-        contact: { name: ecName.value.trim(), phone: ecPhone.value.trim(), relationship: ecRel.value.trim() }
-      },
-      created: new Date().toISOString()
+      bloodType: cBlood.value.trim(),
+      allergies: cAllergies.value.trim(),
+      contact: { name: ecName.value.trim(), phone: ecPhone.value.trim(), relationship: ecRel.value.trim() }
     };
-    // In your app you might store clientInfo keyed by GUID locally or remotely.
-    // This demo intentionally avoids network I/O to keep PII on-device.
+
+    const result = await ThreeLayerEncryption.buildRecord(
+      emergencyInfo,
+      {},
+      {},
+      pinEl.value.trim()
+    );
+
+    currentGUID = result.guid;
+    currentKey = result.qrKey;
+    guidEl.value = currentGUID; keyEl.value = currentKey;
+
+    try {
+      localStorage.setItem(`clientRecord.${currentGUID}`, JSON.stringify(result.storedData));
+    } catch {}
+
     showToast('QR generated');
     updateOutputs();
   });

--- a/test/crypto.test.js
+++ b/test/crypto.test.js
@@ -8,9 +8,19 @@ const { ThreeLayerEncryption } = require('../app.js');
   const key1 = await ThreeLayerEncryption.derivePinKey(pin, salt);
   const key2 = await ThreeLayerEncryption.derivePinKey(pin, salt);
   assert.strictEqual(key1, key2, 'derivePinKey should be deterministic');
+
   const secret = { foo: 'bar', baz: 42 };
   const enc = await ThreeLayerEncryption.encrypt(secret, key1);
   const dec = await ThreeLayerEncryption.decrypt(enc, key1);
   assert.deepStrictEqual(dec, secret, 'encrypt/decrypt round trip');
+
+  const record = await ThreeLayerEncryption.buildRecord(secret, { private: 's' }, { docs: [] }, pin);
+  const pub = await ThreeLayerEncryption.unlockPublic(record.storedData, record.qrKey);
+  assert.deepStrictEqual(pub, secret, 'unlockPublic returns original data');
+  const priv = await ThreeLayerEncryption.unlockPrivate(record.storedData, pin);
+  assert.deepStrictEqual(priv, { private: 's' }, 'unlockPrivate returns original data');
+  const vault = await ThreeLayerEncryption.unlockVault(record.storedData, record.qrKey);
+  assert.deepStrictEqual(vault, { docs: [] }, 'unlockVault returns original data');
+
   console.log('All crypto tests passed');
 })();


### PR DESCRIPTION
## Summary
- Derive and use PIN keys for private info, removing password gate from ThreeLayerEncryption
- Default viewer URL to the current directory and drop unused pin param in buildUrl
- Generate and store encrypted records during intake flow
- Expand crypto tests to cover record creation and unlocking

## Testing
- `node test/crypto.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68b11901abcc8332b8041b760b36c8c4