### PR TITLE
Use PIN-derived key for private info decryption

### DIFF
--- a/SYSTEM_DESIGN.md
+++ b/SYSTEM_DESIGN.md
@@ -71,10 +71,11 @@ sequenceDiagram
     participant A as App
     participant E as ThreeLayerEncryption
     U->>A: Enter emergency & medical data
-    A->>E: buildRecord(info, private, vault, password)
+    A->>E: buildRecord(info, private, vault, pin)
     E->>E: generateQrKey()
     E->>E: encrypt(publicData, qrKey)
-    E->>E: sha256(qrKey+password)
+    E->>E: derivePinKey(pin, pinSalt)
+    E->>E: encrypt(private, derivedPinKey)
     E->>E: deriveKey(qrKey, salt)
     E->>E: encrypt(vault, derivedKey)
     E-->>A: guid, qrKey, storedData

--- a/index.html
+++ b/index.html
@@ -2387,9 +2387,7 @@
                         return;
                     }
                     try {
-                        const salt = new Uint8Array(ThreeLayerEncryption.base64ToArrayBuffer(fullData.pinSalt));
-                        const key = await ThreeLayerEncryption.derivePinKey(pin, salt);
-                        const priv = await ThreeLayerEncryption.decrypt(fullData.privateCipher, key);
+                        const priv = await ThreeLayerEncryption.unlockPrivate(fullData, pin);
                         privateDataEl.textContent = JSON.stringify(priv, null, 2);
                         pinForm.style.display = 'none';
                     } catch (err) {

--- a/test/crypto.test.js
+++ b/test/crypto.test.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const { ThreeLayerEncryption } = require('../app.js');
+globalThis.crypto = globalThis.crypto || require('crypto').webcrypto;
 
 (async () => {
   globalThis.self = globalThis;
@@ -12,5 +13,15 @@ const { ThreeLayerEncryption } = require('../app.js');
   const enc = await ThreeLayerEncryption.encrypt(secret, key1);
   const dec = await ThreeLayerEncryption.decrypt(enc, key1);
   assert.deepStrictEqual(dec, secret, 'encrypt/decrypt round trip');
+  const emergencyInfo = { name: 'Alice' };
+  const privateInfo = { ssn: '111-22-3333' };
+  const health = { records: [] };
+  const record = await ThreeLayerEncryption.buildRecord(emergencyInfo, privateInfo, health, pin);
+  const unlocked = await ThreeLayerEncryption.unlockPrivate(record.storedData, pin);
+  assert.deepStrictEqual(unlocked, privateInfo, 'unlockPrivate should decrypt private info');
+  await assert.rejects(
+    ThreeLayerEncryption.unlockPrivate(record.storedData, '000000'),
+    /Invalid PIN/
+  );
   console.log('All crypto tests passed');
 })();


### PR DESCRIPTION
## Summary
- Derive an AES key from the user PIN and stored salt to decrypt private data.
- Remove password parameter from record creation and update docs and UI to use PIN-based unlock.
- Extend crypto tests to cover building a record and validating PIN failure.

## Testing
- `node test/crypto.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68b11959036c8332a5eef0d0eb1247bb