### PR TITLE
Delay QR generation until client info and PIN provided

### DIFF
--- a/client-qr-creator.html
+++ b/client-qr-creator.html
@@ -250,14 +250,16 @@
     urlOut.textContent = url;
     renderQR(url);
   }
-  updateOutputs();
 
   // ——— Actions ———
   document.getElementById('regenAll').addEventListener('click', ()=>{
     currentGUID = generateGUID();
     currentKey = generateKey();
     guidEl.value = currentGUID; keyEl.value = currentKey;
-    updateOutputs(); showToast('New IDs generated');
+    // Do not generate a new QR until the user saves their info and PIN
+    urlOut.textContent = '—';
+    qrBox.innerHTML = '';
+    showToast('New IDs generated');
   });
 
   document.getElementById('saveClient').addEventListener('click', async ()=>{


### PR DESCRIPTION
## Summary
- Stop rendering QR codes on page load and when regenerating IDs
- Clear QR and URL outputs until user submits client info and PIN
- Keep QR generation tied to validated Save action

## Testing
- `node test/crypto.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68b1222277e8833281342dd994fd9751