### PR TITLE
Launch profile after generating QR

### DIFF
--- a/client-qr-creator.html
+++ b/client-qr-creator.html
@@ -249,6 +249,7 @@
     const url = buildUrl(currentGUID,currentKey);
     urlOut.textContent = url;
     renderQR(url);
+    return url;
   }
 
   // ——— Actions ———
@@ -288,7 +289,8 @@
     } catch {}
 
     showToast('QR generated');
-    updateOutputs();
+    const profileUrl = updateOutputs();
+    window.open(profileUrl, '_blank');
   });
 
   document.getElementById('clearForm').addEventListener('click', ()=>{


### PR DESCRIPTION
## Summary
- Open the profile viewer automatically after creating a client QR code
- Return the generated URL when updating QR outputs

## Testing
- `node test/crypto.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68b1234b9e38833286edf78914e7e899