### PR TITLE
Show emergency info when QR hash present

### DIFF
--- a/index.html
+++ b/index.html
@@ -3957,14 +3957,18 @@
              }
          }
 
-        // Add click handler for logo to return to client creator
+        // Add click handler for logo and select initial tab
         document.addEventListener('DOMContentLoaded', function() {
             const logo = document.querySelector('.logo');
             if (logo) {
                 logo.addEventListener('click', showClientCreator);
             }
-            // Always show the client creator on initial load
-            showClientCreator();
+            // If a QR hash is present, show the emergency view. Otherwise default to the client creator.
+            if (window.location.hash) {
+                showQRTab();
+            } else {
+                showClientCreator();
+            }
         });
 
          // Allow closing dev tools


### PR DESCRIPTION
## Summary
- Show emergency information view when visiting a URL with a QR hash
- Keep client creator as default when no hash is present

## Testing
- `node test/crypto.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68b124b939d08332a56d103817ab8f89