### PR TITLE
Allow editing after PIN unlock

### DIFF
--- a/index.html
+++ b/index.html
@@ -1724,12 +1724,13 @@
             if (enteredHash === currentBlob.pinHash) {
                 pinUnlocked = true;
                 currentPIN = enteredPin;
+                grantOwnerAccess(enteredPin);
                 closePinPad();
-                
+
                 if (window.pinCallback) {
                     window.pinCallback(true, enteredPin);
                 }
-                
+
                 // Refresh the display
                 displayEmergencyInfo(currentBlob);
             } else {
@@ -2619,14 +2620,18 @@
         }
 
         // ============= OWNER FUNCTIONS =============
+        function grantOwnerAccess(password) {
+            ownerPassword = password;
+            document.querySelector('.login-btn').style.display = 'none';
+            document.querySelector('.dashboard-btn').style.display = 'inline-block';
+            document.querySelector('.logout-btn').style.display = 'inline-block';
+            document.querySelector('.health-records-btn').style.display = 'inline-block';
+        }
+
         async function ownerLogin() {
             const password = prompt('Enter owner password:');
             if (password === 'demo123') {  // For testing
-                ownerPassword = password;
-                document.querySelector('.login-btn').style.display = 'none';
-                document.querySelector('.dashboard-btn').style.display = 'inline-block';
-                document.querySelector('.logout-btn').style.display = 'inline-block';
-                document.querySelector('.health-records-btn').style.display = 'inline-block';
+                grantOwnerAccess(password);
                 showOwnerDashboard();
             } else {
                 alert('Invalid password');


### PR DESCRIPTION
## Summary
- Automatically grant owner access once a valid PIN is entered
- Share UI logic between PIN unlock and owner login via new `grantOwnerAccess`

## Testing
- `node test/crypto.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68b1ba52f7c4833280b25cf8bc335d77