### PR TITLE
Protect emergency contact info behind PIN

### DIFF
--- a/index.html
+++ b/index.html
@@ -1890,16 +1890,17 @@
             html += `</div>`; // Close basic section
 
             // PIN-protected sections
-            if (fullData.pinProtected && !pinUnlocked) {
+            const hasPrivateInfo = publicInfo.medications || publicInfo.contact;
+            if (hasPrivateInfo && !pinUnlocked) {
                 html += `
                     <div class="private-section">
                         <h3>🔒 Additional Information</h3>
-                        <p>This section contains medications and contact information.</p>
+                        <p>This section contains medications and emergency contact details.</p>
                         <button class="btn btn-outline" onclick="requestPinUnlock()">
                             Enter PIN to View
                         </button>
                     </div>`;
-            } else if (pinUnlocked || !fullData.pinProtected) {
+            } else if (hasPrivateInfo && pinUnlocked) {
                 // Show PIN-protected content
                 if (publicInfo.medications) {
                     html += `


### PR DESCRIPTION
## Summary
- Hide medication and emergency contact details until the user enters the PIN

## Testing
- `node test/crypto.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68b1bc0889ec8332ac51e6112cc17d28